### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.pinokiod-server
+++ b/Dockerfile.pinokiod-server
@@ -1,0 +1,19 @@
+FROM node:14
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 42000
+CMD [ "node", "script/index" ]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO pinokiod
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,39 @@
+namespace: pinokiod
+
+pinokiod-server:
+  defines: runnable
+  metadata:
+    name: pinokiod-server
+    description: Main HTTP server handling web requests and serving static files.
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg
+  containers:
+    pinokiod-server:
+      image: env-4671.registry.local/pinokiod-server:main-c8j0oc
+      build: .
+      dockerfile: Dockerfile.pinokiod-server
+  services:
+    http-server-port:
+      description: HTTP server port
+      container: pinokiod-server
+      port: 42000
+      host-port: 42000
+      publish: true
+      protocol: tcp
+  connections:
+    websocket-connection:
+      target: pinokiod/client
+      service: '!!!SETME!!!'
+      optional: true
+      description: WebSocket connection for real-time communication with clients
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - pinokiod/pinokiod-server
+  metadata:
+    name: pinokiod
+    description: >-
+      Node.js application that sets up an HTTP server using Express.js to handle
+      HTTP requests and manage server configurations.
+    icon: https://emojiapi.dev/api/v1/package.svg


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Changes Made

- **Dockerfile Creation**: I created a Dockerfile named `Dockerfile.pinokiod-server` for the `pinokiod-server` service. This Dockerfile is configured to set up the environment, install dependencies, and start the server using the `node script/index.js` command, which is the entry point of the application.
- **Monk Configuration**: Added a `monk.yaml` file containing the Monk.io configuration and a `MANIFEST` file listing all files with Monk configurations. These are necessary for the deployment and orchestration of the application using Monk.io.
- **Service Mapping**: Mapped the services required by the `pinokiod-server` application. The application is self-contained, with no external services like databases detected. It uses various Node.js modules and custom modules from within the repository.
- **WebSocket Configuration**: Identified that the `pinokiod-server` service establishes WebSocket connections for real-time communication with clients. The service exposes port 42000 for HTTP server communication.

## Encountered Problems

- **Missing Client Service Information**: I was unable to complete the composition of services as there is no information provided about the 'client' service. This information is necessary to set the 'websocket-connection' target port for the `pinokiod-server` service.

## Instructions to Continue

- **Client Service Details**: To continue with the service composition, the exposed port names of the 'client' service need to be identified. Once this information is available, the 'websocket-connection' target port can be set correctly in the configuration.
- **Deprecation Warnings**: Address the deprecation warnings related to `express-session` configuration in the application code to ensure future compatibility and best practices.

Upon merging this PR, the application will be re-deployed on each subsequent push, assuming all dependencies and environment variables are provided in the complete environment.